### PR TITLE
Update LSTM.ipynb

### DIFF
--- a/LSTM/LSTM.ipynb
+++ b/LSTM/LSTM.ipynb
@@ -54,7 +54,7 @@
     "import numpy as np\n",
     "import tensorflow as tf\n",
     "from sklearn import datasets\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "import pylab as pl\n",
     "from IPython import display\n",
     "import sys\n",


### PR DESCRIPTION
`sklearn.cross_validation` is deprecated. Instead you can use `sklearn.model_selection` 